### PR TITLE
fix: 解决在rn-tester框架中，进入Babylon Demo后，返回再次进入Babylon Demo后，await BabylonNative.initializationPromise无法返回，引擎无法成功创建问题

### DIFF
--- a/react-native-harmony/harmony/rn_babylon/src/main/cpp/RNBabylonModule.h
+++ b/react-native-harmony/harmony/rn_babylon/src/main/cpp/RNBabylonModule.h
@@ -34,10 +34,10 @@ namespace rnoh {
         
         BabylonNative::Dispatcher createJsDispatcher(Context context) {
             return [context](std::function<void()> job) {
-                if (!context.taskExecutor) {
+                if (!context.jsInvoker) {
                     return;
                 }
-                context.taskExecutor->runTask(TaskThread::JS, [job = std::move(job)]() { job(); });
+                context.jsInvoker->invokeAsync([job = std::move(job)](){ job(); });
             };
         }
 


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- 解决在rn-tester框架中，进入Babylon Demo后，返回再次进入Babylon Demo后，await BabylonNative.initializationPromise无法返回，引擎无法成功创建问题。

## Test Plan

<img width="396" height="859" alt="image" src="https://github.com/user-attachments/assets/7e043167-e6d6-4d02-aeee-01835e429042" />

进入Babylon Demo：
<img width="399" height="863" alt="image" src="https://github.com/user-attachments/assets/582bf559-3aaa-4a2e-b4b8-1b158f33ef8f" />

返回，再次进入Babylon Demo：
<img width="400" height="856" alt="image" src="https://github.com/user-attachments/assets/f5d48248-6ac6-4586-a195-6f5a03b6a09e" />

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)