### PR TITLE
fix: 解决抗锯齿等级超过当前EGL环境显卡支持的最大MSAA时，bgfx异常退出问题

### DIFF
--- a/react-native-harmony/harmony/rn_babylon/src/main/cpp/BaseNativeEngineViewComponentInstance.h
+++ b/react-native-harmony/harmony/rn_babylon/src/main/cpp/BaseNativeEngineViewComponentInstance.h
@@ -35,6 +35,7 @@ namespace rnoh {
         ~BaseNativeEngineViewComponentInstance();
         void onChildInserted(ComponentInstance::Shared const &childComponentInstance, std::size_t index) override;
         void onChildRemoved(ComponentInstance::Shared const &childComponentInstance) override;
+        int getMaxMSAASamples();
         void onSnapshoting();
         void onPropsChanged(SharedConcreteProps const &props) override;
         void handleCommand(std::string const &commandName, folly::dynamic const &args) override;


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- 解决抗锯齿等级超过当前EGL环境显卡支持的最大MSAA时，bgfx异常退出问题。

## Test Plan

onPropsChanged antiAliasing:8
the maximum MSAA supported by the graphics card in the current EGL: 4
![IMG_1763536901_139](https://github.com/user-attachments/assets/82d4e529-95b7-4ba1-8ba6-5790ddfbf841)
hanged antiAliasing:8

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
