### PR TITLE
fix:解决JsRuntimeHost的CMakeLists.txt里include和source目录首字母和实际目录大小写不一致问题

### DIFF
--- a/react-native-harmony/harmony/rn_babylon/src/main/cpp/shared/CMakeLists.txt
+++ b/react-native-harmony/harmony/rn_babylon/src/main/cpp/shared/CMakeLists.txt
@@ -2,7 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(babylonnative
     GIT_REPOSITORY https://gitee.com/openharmony-tpc-incubate/BabylonNative.git
-    GIT_TAG 3f9f9160f3d61f58a94b9a73d6d08bf1b156d427)
+    GIT_TAG 8d8dec5644e8c20a77ffb5644c716ce5901b96d4)
 
 set(SHARED_INCLUDES
     "${CMAKE_CURRENT_LIST_DIR}")


### PR DESCRIPTION
# Summary

- 解决JsRuntimeHost的CMakeLists.txt里include和source目录首字母和实际目录大小写不一致问题

## Test Plan

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)